### PR TITLE
Feat/enable-chain-number

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -1,6 +1,9 @@
 [profile.default]
 fs_permissions = [{ access = "read-write", path = "./" }]
 
+[rpc_endpoints]
+sepolia = "https://ethereum-sepolia.publicnode.com"
+
 [fmt]
 # These are all the `forge fmt` defaults.
 line_length = 120

--- a/src/Action.sol
+++ b/src/Action.sol
@@ -2,10 +2,11 @@
 pragma solidity >=0.6.2 <0.9.0;
 pragma experimental ABIEncoderV2;
 
-import {Script} from "forge-std/Script.sol";
-import {Phylax} from "./Phylax.sol";
+import { Script } from "forge-std/Script.sol";
+import { PhylaxBase } from "./PhylaxBase.sol";
 
-// Base contract for all Phylax alert contracts.
-abstract contract Action is Script {
-    Phylax internal constant ph = Phylax(VM_ADDRESS);
+/// @title Alert
+/// @dev Base contract for all Phylax alert contracts.
+abstract contract Action is PhylaxBase, Script {
+
 }

--- a/src/Alert.sol
+++ b/src/Alert.sol
@@ -2,33 +2,42 @@
 pragma solidity >=0.6.2 <0.9.0;
 pragma experimental ABIEncoderV2;
 
-import {Test} from "forge-std/Test.sol";
-import {Phylax} from "./Phylax.sol";
+import { Test } from "forge-std/Test.sol";
+import { Phylax } from "./Phylax.sol";
 
 /// @title Alert
 /// @dev Base contract for all Phylax alert contracts.
 abstract contract Alert is Test {
-    /// @dev Phylax instance
-    Phylax internal constant ph = Phylax(VM_ADDRESS);
+  /// @dev Phylax instance
+  Phylax internal constant ph = Phylax(VM_ADDRESS);
 
-    /// @dev Array of active chains
-    uint256[] internal $activeChains;
+  /// @dev Array of active chains
+  uint256[] internal $activeChains;
 
-    /// @notice Enables a new chain
-    /// @param aliasOrUrl The alias or URL of the chain to enable. The alias is used
-    /// when the RPC is defined in `foundry.toml`, as in Forge fork tests.
-    /// @return The index of the newly enabled chain
-    function enableChain(string calldata aliasOrUrl) internal returns (uint256) {
-        $activeChains.push(vm.createFork(aliasOrUrl));
-        return $activeChains.length - 1;
-    }
+  /// @notice Enables a new chain
+  /// @param aliasOrUrl The alias or URL of the chain to enable. The alias is used
+  /// when the RPC is defined in `foundry.toml`, as in Forge fork tests.
+  /// @return The index of the newly enabled forked chain
+  function enableChain(string calldata aliasOrUrl) internal returns (uint256) {
+    $activeChains.push(vm.createFork(aliasOrUrl));
+    return $activeChains.length - 1;
+  } /// @notice Enables a new chain
 
-    /// @notice Modifier to select a chain
-    /// @dev Exports "fork_activated" and selects the fork at the given index
-    /// @param index The index of the chain to select
-    modifier chain(uint256 index) {
-        ph.export("phylax_fork_activated", "");
-        vm.selectFork($activeChains[index]);
-        _;
-    }
+  /// @param aliasOrUrl The alias or URL of the chain to enable. The alias is used
+  /// when the RPC is defined in `foundry.toml`, as in Forge fork tests.
+  /// @param blockNumber The block number at which the chain should be forked
+  /// @return The index of the newly enabled forked chain
+  function enableChain(string calldata aliasOrUrl, uint256 blockNumber) internal returns (uint256) {
+    $activeChains.push(vm.createFork(aliasOrUrl, blockNumber));
+    return $activeChains.length - 1;
+  }
+
+  /// @notice Modifier to select a chain
+  /// @dev Exports "fork_activated" and selects the fork at the given index
+  /// @param index The index of the chain to select
+  modifier chain(uint256 index) {
+    ph.export("phylax_fork_activated", "");
+    vm.selectFork($activeChains[index]);
+    _;
+  }
 }

--- a/src/Alert.sol
+++ b/src/Alert.sol
@@ -3,41 +3,10 @@ pragma solidity >=0.6.2 <0.9.0;
 pragma experimental ABIEncoderV2;
 
 import { Test } from "forge-std/Test.sol";
-import { Phylax } from "./Phylax.sol";
+import { PhylaxBase } from "./PhylaxBase.sol";
 
 /// @title Alert
 /// @dev Base contract for all Phylax alert contracts.
-abstract contract Alert is Test {
-  /// @dev Phylax instance
-  Phylax internal constant ph = Phylax(VM_ADDRESS);
+abstract contract Alert is PhylaxBase, Test {
 
-  /// @dev Array of active chains
-  uint256[] internal $activeChains;
-
-  /// @notice Enables a new chain
-  /// @param aliasOrUrl The alias or URL of the chain to enable. The alias is used
-  /// when the RPC is defined in `foundry.toml`, as in Forge fork tests.
-  /// @return The index of the newly enabled forked chain
-  function enableChain(string calldata aliasOrUrl) internal returns (uint256) {
-    $activeChains.push(vm.createFork(aliasOrUrl));
-    return $activeChains.length - 1;
-  } /// @notice Enables a new chain
-
-  /// @param aliasOrUrl The alias or URL of the chain to enable. The alias is used
-  /// when the RPC is defined in `foundry.toml`, as in Forge fork tests.
-  /// @param blockNumber The block number at which the chain should be forked
-  /// @return The index of the newly enabled forked chain
-  function enableChain(string calldata aliasOrUrl, uint256 blockNumber) internal returns (uint256) {
-    $activeChains.push(vm.createFork(aliasOrUrl, blockNumber));
-    return $activeChains.length - 1;
-  }
-
-  /// @notice Modifier to select a chain
-  /// @dev Exports "fork_activated" and selects the fork at the given index
-  /// @param index The index of the chain to select
-  modifier chain(uint256 index) {
-    ph.export("phylax_fork_activated", "");
-    vm.selectFork($activeChains[index]);
-    _;
-  }
 }

--- a/src/Phylax.sol
+++ b/src/Phylax.sol
@@ -2,10 +2,22 @@
 pragma solidity >=0.6.2 <0.9.0;
 pragma experimental ABIEncoderV2;
 
-// Vm-like interface for Phylax. It includes cheatcodes that are available
-// in the phylax fork of foundry, but have bnot been upstreamed
-interface Phylax {
-    // Export a name/value pairt to Phylax. It's exposed via the API and
-    // if it's numerical, via the prometheus endpoint as well.
-    function export(string calldata name, string calldata value) external;
+import { console } from "forge-std/console.sol";
+import { CommonBase } from "forge-std/Base.sol";
+
+/// @title Vm-like interface for Phylax
+/// @dev It includes cheatcodes that are available in the phylax fork of foundry, but have not been upstreamed
+contract Phylax is CommonBase {
+  /// @dev The internal cheatcode address that is used by forge
+  Phylax internal constant _ph = Phylax(VM_ADDRESS);
+
+  /// @notice Export a name/value pair to Phylax
+  /// @dev It's exposed via the API and if it's numerical, via the prometheus endpoint as well.
+  /// @param name The name of the value to export
+  /// @param value The value to export
+  function export(string memory name, string memory value) external {
+    try _ph.export(name, value) {} catch {
+      console.log("'ph.export(string,string) reverted. This is normal if the code was run by vanilla 'forge'.");
+    }
+  }
 }

--- a/src/PhylaxBase.sol
+++ b/src/PhylaxBase.sol
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.6.2 <0.9.0;
+pragma experimental ABIEncoderV2;
+
+import { CommonBase } from "forge-std/Base.sol";
+import { Phylax } from "./Phylax.sol";
+
+/// @title Alert
+/// @dev Base contract for all Phylax alert contracts.
+abstract contract PhylaxBase is CommonBase {
+  /// @dev Instance of Phylax contract
+  Phylax ph;
+
+  /// @notice Sets up the Phylax contract
+  /// @dev Instantiates a new Phylax contract and assigns it to the ph variable
+  function setupPhylax() public {
+    ph = new Phylax();
+  }
+
+  /// @dev Array of active chains
+  uint256[] internal $activeChains;
+
+  /// @notice Enables a new chain
+  /// @param aliasOrUrl The alias or URL of the chain to enable. The alias is used
+  /// when the RPC is defined in `foundry.toml`, as in Forge fork tests.
+  /// @return The index of the newly enabled forked chain
+  function enableChain(string memory aliasOrUrl) internal ensurePhylaxSetup returns (uint256) {
+    $activeChains.push(vm.createFork(aliasOrUrl));
+    return $activeChains.length - 1;
+  } /// @notice Enables a new chain
+
+  /// @param aliasOrUrl The alias or URL of the chain to enable. The alias is used
+  /// when the RPC is defined in `foundry.toml`, as in Forge fork tests.
+  /// @param blockNumber The block number at which the chain should be forked
+  /// @return The index of the newly enabled forked chain
+  function enableChain(string memory aliasOrUrl, uint256 blockNumber) internal ensurePhylaxSetup returns (uint256) {
+    $activeChains.push(vm.createFork(aliasOrUrl, blockNumber));
+    return $activeChains.length - 1;
+  }
+
+  /// @notice Modifier to select a chain
+  /// @dev Exports "fork_activated" and selects the fork at the given index
+  /// @param index The index of the chain to select
+  modifier chain(uint256 index) {
+    vm.selectFork($activeChains[index]);
+    _;
+  }
+
+  /// @notice Modifier to ensure Phylax is setup
+  /// @dev Instantiates Phylax if not already setup
+  modifier ensurePhylaxSetup() {
+    if (address(ph) == address(0)) {
+      setupPhylax();
+    }
+    _;
+  }
+}

--- a/src/PhylaxBase.sol
+++ b/src/PhylaxBase.sol
@@ -9,12 +9,14 @@ import { Phylax } from "./Phylax.sol";
 /// @dev Base contract for all Phylax alert contracts.
 abstract contract PhylaxBase is CommonBase {
   /// @dev Instance of Phylax contract
-  Phylax ph;
+  Phylax internal ph;
+  bool internal phylax_setup;
 
   /// @notice Sets up the Phylax contract
   /// @dev Instantiates a new Phylax contract and assigns it to the ph variable
   function setupPhylax() public {
     ph = new Phylax();
+    phylax_setup = true;
   }
 
   /// @dev Array of active chains
@@ -49,7 +51,7 @@ abstract contract PhylaxBase is CommonBase {
   /// @notice Modifier to ensure Phylax is setup
   /// @dev Instantiates Phylax if not already setup
   modifier ensurePhylaxSetup() {
-    if (address(ph) == address(0)) {
+    if (!phylax_setup) {
       setupPhylax();
     }
     _;

--- a/src/PhylaxBase.sol
+++ b/src/PhylaxBase.sol
@@ -10,17 +10,16 @@ import { Phylax } from "./Phylax.sol";
 abstract contract PhylaxBase is CommonBase {
   /// @dev Instance of Phylax contract
   Phylax internal ph;
-  bool internal phylax_setup;
+  bool internal $phylax_setup;
+  /// @dev Array of active chains
+  uint256[] internal $activeChains;
 
   /// @notice Sets up the Phylax contract
   /// @dev Instantiates a new Phylax contract and assigns it to the ph variable
   function setupPhylax() public {
     ph = new Phylax();
-    phylax_setup = true;
+    $phylax_setup = true;
   }
-
-  /// @dev Array of active chains
-  uint256[] internal $activeChains;
 
   /// @notice Enables a new chain
   /// @param aliasOrUrl The alias or URL of the chain to enable. The alias is used
@@ -51,7 +50,7 @@ abstract contract PhylaxBase is CommonBase {
   /// @notice Modifier to ensure Phylax is setup
   /// @dev Instantiates Phylax if not already setup
   modifier ensurePhylaxSetup() {
-    if (!phylax_setup) {
+    if (!$phylax_setup) {
       setupPhylax();
     }
     _;

--- a/test/Alert.t.sol
+++ b/test/Alert.t.sol
@@ -1,6 +1,0 @@
-// SPDX-License-Identifier: MIT
-pragma solidity >=0.7.0 <0.9.0;
-
-import "../src/Alert.sol";
-
-contract AlertTest is Alert {}

--- a/test/PhylaxBase.t.sol
+++ b/test/PhylaxBase.t.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.7.0 <0.9.0;
+import { PhylaxBase } from "../src/PhylaxBase.sol";
+
+contract PhylaxBaseTest is PhylaxBase {
+  uint256 sepolia;
+
+  function setUp() public {
+    assert(!phylax_setup);
+    sepolia = enableChain("sepolia");
+  }
+
+  function test_fork() public chain(sepolia) {
+    assert(block.number != 0);
+  }
+
+  function test_phylax_setup() public view {
+    assert(phylax_setup);
+  }
+}

--- a/test/PhylaxBase.t.sol
+++ b/test/PhylaxBase.t.sol
@@ -6,15 +6,20 @@ contract PhylaxBaseTest is PhylaxBase {
   uint256 sepolia;
 
   function setUp() public {
-    assert(!phylax_setup);
+    assert(!$phylax_setup);
     sepolia = enableChain("sepolia");
   }
 
-  function test_fork() public chain(sepolia) {
+  function testFork() public chain(sepolia) {
     assert(block.number != 0);
   }
 
-  function test_phylax_setup() public view {
-    assert(phylax_setup);
+  function testPhylaxSetup() public view {
+    assert($phylax_setup);
+  }
+
+  function testChainsArray() public view {
+    assert($activeChains.length == 1);
+    assert($activeChains[0] == sepolia);
   }
 }

--- a/test/PhylaxBase.t.sol
+++ b/test/PhylaxBase.t.sol
@@ -10,7 +10,7 @@ contract PhylaxBaseTest is PhylaxBase {
     sepolia = enableChain("sepolia");
   }
 
-  function testFork() public chain(sepolia) {
+  function testChainModifier() public chain(sepolia) {
     assert(block.number != 0);
   }
 


### PR DESCRIPTION
Also, when enabling a chain, it will try to setup the phylax contract.

The phylax contract is like the vm, but in case the cheatcode revets, it just logs it.

new versions of foundry revert with unknown cheatcodes